### PR TITLE
Replace retrofit dependency with okhttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
             <version>${fasterxml-uuid.version}</version>
         </dependency>
         <dependency>
-			<groupId>com.squareup.retrofit2</groupId>
-			<artifactId>retrofit</artifactId>
-			<version>2.0.0-beta3</version>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>3.6.0</version>
 		</dependency>
     </dependencies>
 


### PR DESCRIPTION
We are using the okhttp dependency of retrofit and nothing else from it.

@bdionne , @rgrinberg 