### PR TITLE
Flatten lists of lists of ontology changes

### DIFF
--- a/src/main/java/org/protege/editor/owl/client/ui/OpenFromServerPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/ui/OpenFromServerPanel.java
@@ -153,10 +153,15 @@ public class OpenFromServerPanel extends JPanel {
             clientSession.setActiveProject(pid, vont);
             
             // update index with possibly new changes from other modelers
+            List<OWLOntologyChange> changes = new ArrayList<OWLOntologyChange>();
             
             for (List<OWLOntologyChange> c : vont.getChangeHistory().getRevisions().values()) {
-            	editorKit.getSearchManager().updateIndex(c);            	
+            	for (OWLOntologyChange oc : c) {
+            		changes.add(oc);
+            	}            	            	
             }
+            
+            editorKit.getSearchManager().updateIndex(changes);
             
             closeDialog();
         }


### PR DESCRIPTION
Making one call to the indexer ought to go a little faster than multiple calls