### PR TITLE
Improve error codes on failures

### DIFF
--- a/src/main/java/org/protege/editor/owl/client/LocalHttpClient.java
+++ b/src/main/java/org/protege/editor/owl/client/LocalHttpClient.java
@@ -698,7 +698,7 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		String originalMessage = response.header("Error-Message");
 		if (originalMessage == null) {
-			originalMessage = "Unknown server error";
+			originalMessage = String.format("Unknown server error (code: %d)", response.code());
 		}
 		if (response.code() == StatusCodes.UNAUTHORIZED) {
 			throw new AuthorizationException(originalMessage);


### PR DESCRIPTION
Show the HTTP error code when the server doesn't give us a proper error message

@bdionne this was also a helpful little bit for me to know when the admin
was accidentally hitting the user endpoint