### PR TITLE
Add squash & resume support

### DIFF
--- a/src/main/java/org/protege/editor/owl/client/ClientSession.java
+++ b/src/main/java/org/protege/editor/owl/client/ClientSession.java
@@ -103,8 +103,8 @@ public class ClientSession extends OWLEditorKitHook {
 
     public void setActiveClient(Client client) {
         if (!hasActiveClient()) {
-            activeClient = client;            
-            getEditorKit().getWorkspace().setCheckLevel(new TabViewableChecker(client));
+            activeClient = client;
+            getEditorKit().getWorkspace().setCheckLevel(new TabViewableChecker(this, client));
             getEditorKit().getWorkspace().recheckPlugins();
             if (((LocalHttpClient) client).getClientType() == UserType.ADMIN) {
             	WorkspaceTab admin = getEditorKit().getOWLWorkspace().getWorkspaceTab("metaproject-admin.AdminTab");

--- a/src/main/java/org/protege/editor/owl/client/LocalHttpClient.java
+++ b/src/main/java/org/protege/editor/owl/client/LocalHttpClient.java
@@ -1,5 +1,8 @@
 package org.protege.editor.owl.client;
 
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import edu.stanford.protege.metaproject.ConfigurationManager;
 import edu.stanford.protege.metaproject.api.*;
 import edu.stanford.protege.metaproject.api.exception.ObjectConversionException;
@@ -7,28 +10,28 @@ import edu.stanford.protege.metaproject.api.exception.UnknownProjectIdException;
 import edu.stanford.protege.metaproject.api.exception.UnknownUserIdException;
 import edu.stanford.protege.metaproject.impl.AuthorizedUserToken;
 import edu.stanford.protege.metaproject.impl.RoleIdImpl;
+import edu.stanford.protege.metaproject.impl.ServerStatus;
 import edu.stanford.protege.metaproject.serialization.DefaultJsonSerializer;
 import io.undertow.util.StatusCodes;
 import okhttp3.*;
 import org.apache.commons.codec.binary.Base64;
 import org.protege.editor.owl.client.api.Client;
 import org.protege.editor.owl.client.api.UserInfo;
-import org.protege.editor.owl.client.api.exception.AuthorizationException;
-import org.protege.editor.owl.client.api.exception.ClientRequestException;
-import org.protege.editor.owl.client.api.exception.LoginTimeoutException;
-import org.protege.editor.owl.client.api.exception.SynchronizationException;
+import org.protege.editor.owl.client.api.exception.*;
 import org.protege.editor.owl.client.event.ClientSessionChangeEvent;
 import org.protege.editor.owl.client.event.ClientSessionChangeEvent.EventCategory;
 import org.protege.editor.owl.client.event.ClientSessionListener;
 import org.protege.editor.owl.client.util.ClientUtils;
 import org.protege.editor.owl.client.util.Config;
 import org.protege.editor.owl.server.api.CommitBundle;
+import org.protege.editor.owl.server.http.ServerProperties;
 import org.protege.editor.owl.server.http.messages.History;
 import org.protege.editor.owl.server.http.messages.HttpAuthResponse;
 import org.protege.editor.owl.server.http.messages.LoginCreds;
 import org.protege.editor.owl.server.util.SnapShot;
 import org.protege.editor.owl.server.versioning.VersionedOWLOntologyImpl;
 import org.protege.editor.owl.server.versioning.api.*;
+import org.protege.editor.owl.ui.util.ProgressDialog;
 import org.semanticweb.binaryowl.BinaryOWLOntologyDocumentSerializer;
 import org.semanticweb.binaryowl.owlapi.BinaryOWLOntologyBuildingHandler;
 import org.semanticweb.binaryowl.owlapi.OWLOntologyWrapper;
@@ -39,11 +42,18 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipInputStream;
 
@@ -52,7 +62,7 @@ import static org.protege.editor.owl.server.http.ServerProperties.*;
 
 public class LocalHttpClient implements Client, ClientSessionListener {
 
-	public enum UserType { NON_ADMIN, ADMIN }
+	public enum UserType {NON_ADMIN, ADMIN}
 
 	private static final Logger logger = LoggerFactory.getLogger(LocalHttpClient.class);
 
@@ -61,6 +71,8 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 
 	private static final String authHeader = "Authorization";
 
+	private static final String SNAPSHOT_CHECKSUM = "-checksum";
+
 	private final String serverAddress;
 
 	private final OkHttpClient httpClient;
@@ -68,16 +80,15 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	private UserId userId;
 	private UserInfo userInfo;
 
-	private ProjectId projectId;
-	private Project project;
-
 	private AuthToken authToken;
 
 	//private ServerConfiguration serverConfiguration;
 	private Config config = null;
-	
-	public Config getConfig() { return config; }
-	
+
+	public Config getConfig() {
+		return config;
+	}
+
 	private Serializer serl = new DefaultJsonSerializer();
 
 	private static LocalHttpClient currentHttpClient;
@@ -86,15 +97,15 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	 * The constructor
 	 */
 	public LocalHttpClient(String username, String password, String serverAddress)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException{
+		throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		httpClient = new OkHttpClient.Builder()
-				.writeTimeout(360, TimeUnit.SECONDS)
-				.readTimeout(360, TimeUnit.SECONDS)
-				.build();
+			.writeTimeout(360, TimeUnit.SECONDS)
+			.readTimeout(360, TimeUnit.SECONDS)
+			.build();
 		this.serverAddress = serverAddress;
 		login(username, password);
 		initConfig();
-		initAuthToken();		
+		initAuthToken();
 		LocalHttpClient.currentHttpClient = this;
 	}
 
@@ -105,7 +116,7 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	public ServerConfiguration getCurrentConfig() {
 		return config.getCurrentConfig();
 	}
-	
+
 	public UserType getClientType() {
 		int adminPort = config.getHost().getSecondaryPort().get().get();
 		int serverAddressPort = URI.create(serverAddress).getPort();
@@ -118,11 +129,11 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private void login(String username, String password)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+		throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		LoginCreds creds = new LoginCreds(username, password);
 		Response response = post(LOGIN,
-				RequestBody.create(JsonContentType, serl.write(creds, LoginCreds.class)),
-				false); // send the request to server
+			RequestBody.create(JsonContentType, serl.write(creds, LoginCreds.class)),
+			false); // send the request to server
 		userInfo = retrieveUserInfoFromServerResponse(response);
 		userId = ConfigurationManager.getFactory().getUserId(userInfo.getId());
 	}
@@ -138,7 +149,7 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private UserInfo retrieveUserInfoFromServerResponse(Response response)
-			throws ClientRequestException {
+		throws ClientRequestException {
 		try {
 			InputStream is = response.body().byteStream();
 			HttpAuthResponse authResponse = (HttpAuthResponse) serl.parse(new InputStreamReader(is), HttpAuthResponse.class);
@@ -155,16 +166,9 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 
 	@Override
 	public void handleChange(ClientSessionChangeEvent event) {
-		if (event.equals(EventCategory.SWITCH_ONTOLOGY)) {
-			projectId = event.getSource().getActiveProject();
-		}
+		logger.info("ClientSessionChangeEvent: " + event);
 	}
 
-	
-
-	public Project getCurrentProject() {
-		return project;
-	}
 
 	@Override
 	public AuthToken getAuthToken() {
@@ -172,7 +176,7 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	public ServerDocument createProject(Project project, File font)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+		throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		try {
 			ServerDocument sdoc = postProjectToServer(project);
 			postProjectSnapShotToServer(project, font); // send snapshot to server
@@ -185,11 +189,11 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private ServerDocument postProjectToServer(Project project) throws IOException,
-			LoginTimeoutException, AuthorizationException, ClientRequestException {
+		LoginTimeoutException, AuthorizationException, ClientRequestException {
 		ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(project);
 		Response response = post(PROJECT,
-				RequestBody.create(ApplicationContentType, b.toByteArray()),
-				true); // send the request to server
+			RequestBody.create(ApplicationContentType, b.toByteArray()),
+			true); // send the request to server
 		return retrieveServerDocumentFromServerResponse(response);
 	}
 
@@ -207,7 +211,7 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private ServerDocument retrieveServerDocumentFromServerResponse(Response response)
-			throws ClientRequestException {
+		throws ClientRequestException {
 		try {
 			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
 			ServerDocument sdoc = (ServerDocument) ois.readObject();
@@ -223,16 +227,16 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	@Override
-	public void deleteProject(ProjectId projectId, boolean includeFile)
-			throws AuthorizationException, LoginTimeoutException, ClientRequestException {
+	public void deleteProject(@Nonnull ProjectId projectId, boolean includeFile)
+		throws AuthorizationException, LoginTimeoutException, ClientRequestException {
 		String requestUrl = PROJECT + "?projectid=" + projectId.get();
 		delete(requestUrl, true); // send request to server
 		initConfig();
 	}
 
 	@Override
-	public ServerDocument openProject(ProjectId projectId)
-			throws AuthorizationException, LoginTimeoutException, ClientRequestException {
+	public ServerDocument openProject(@Nonnull ProjectId projectId)
+		throws AuthorizationException, LoginTimeoutException, ClientRequestException {
 		if (getClientType() == UserType.ADMIN) { // admin clients cannot edit/browse ontologies
 			throw new ClientRequestException("Admin clients cannot open projects");
 		}
@@ -242,18 +246,25 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	@Override
-	public ChangeHistory commit(ProjectId projectId, CommitBundle commitBundle)
-			throws AuthorizationException, LoginTimeoutException, SynchronizationException, ClientRequestException {
+	public ChangeHistory commit(@Nonnull ProjectId projectId, CommitBundle commitBundle)
+		throws AuthorizationException, ClientRequestException {
+		checkSnapshotChecksumPresent(projectId);
 		try {
-			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(projectId, commitBundle);
-			Response response = post(COMMIT,
-					RequestBody.create(ApplicationContentType, b.toByteArray()),
+			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(commitBundle);
+			Response response = postWithProjectId(COMMIT,
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				projectId,
 					true); // send request to server
 			return retrieveChangeHistoryFromServerResponse(response);
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
+		}
+	}
+
+	private void checkSnapshotChecksumPresent(@Nonnull ProjectId projectId) {
+		if (!getSnapshotChecksum(projectId).isPresent()) {
+			throw new IllegalArgumentException("Missing snapshot checksum for project " + projectId);
 		}
 	}
 
@@ -275,17 +286,16 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		}
 	}
 
-	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(ProjectId projectId,
+	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(
 			CommitBundle commitBundle) throws IOException {
 		ByteArrayOutputStream b = new ByteArrayOutputStream();
 		ObjectOutputStream os = new ObjectOutputStream(b);
-		os.writeObject(projectId);
 		os.writeObject(commitBundle);
 		return b;
 	}
 
 	private ChangeHistory retrieveChangeHistoryFromServerResponse(Response response)
-			throws ClientRequestException {
+		throws ClientRequestException {
 		try {
 			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
 			ChangeHistory hist = (ChangeHistory) ois.readObject();
@@ -298,12 +308,11 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 				response.body().close();
 			}
 		}
-	}	
+	}
 
 	private List<String> retrieveCodesFromServerResponse(Response response) throws ClientRequestException {
 		try {
 			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
-			@SuppressWarnings("unchecked")
 			List<String> codes = (List<String>) ois.readObject();
 			return codes;
 		} catch (IOException e) {
@@ -312,49 +321,68 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		} catch (ClassNotFoundException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Internal error, server sent wrong object back", e);
-			
+
 		} finally {
 			if (response != null) {
 				response.body().close();
 			}
 		}
-		
+
 	}
 
 	public VersionedOWLOntology buildVersionedOntology(ServerDocument sdoc, OWLOntologyManager owlManager,
-			ProjectId pid) throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+													   @Nonnull ProjectId pid)
+			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+		if (pid == null) throw new IllegalArgumentException("projectId is null");
 		setCurrentProject(pid);
-		if (!getSnapShotFile(sdoc).exists()) {
+		if (!getSnapShotFile(pid).get().exists()) {
 			SnapShot snapshot = getSnapShot(pid);
-			createLocalSnapShot(snapshot.getOntology(), sdoc);
+			createLocalSnapShot(snapshot.getOntology(), pid);
 		}
-		OWLOntology targetOntology = loadSnapShot(owlManager, sdoc);
-		ChangeHistory remoteChangeHistory = getLatestChanges(sdoc, DocumentRevision.START_REVISION);
+		OWLOntology targetOntology = loadSnapShot(owlManager, pid);
+		ChangeHistory remoteChangeHistory = getLatestChanges(sdoc, DocumentRevision.START_REVISION, pid);
 		ClientUtils.updateOntology(targetOntology, remoteChangeHistory, owlManager);
 		return new VersionedOWLOntologyImpl(sdoc, targetOntology, remoteChangeHistory);
 	}
 
-	private void setCurrentProject(ProjectId pid) throws ClientRequestException {
+	private void setCurrentProject(@Nonnull ProjectId pid) throws ClientRequestException {
+		if (pid == null) throw new IllegalArgumentException("projectId is null");
 		try {
-			projectId = pid;
 			config.setActiveProject(pid);
-			project = config.getCurrentConfig().getProject(pid);
+			config.getCurrentConfig().getProject(pid);
 		} catch (UnknownProjectIdException e) {
 			logger.error(e.getMessage());
 			throw new ClientRequestException("Client failed to get the project (see error log for details)", e);
 		}
 	}
 
-	private static File getSnapShotFile(ServerDocument sdoc) {
-		String fname = sdoc.getHistoryFile().getName() + "-snapshot";
-		return new File(fname);
+	private static Optional<File> getSnapShotFile(@Nonnull ProjectId projectId) {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
+		try {
+			Files.createDirectories(Paths.get(projectId.get()));
+		} catch (IOException e) {
+			logger.error("Unable to create snapshot directory for " + projectId + ": " + e);
+			return Optional.empty();
+		}
+		return Optional.of(new File(projectId.get() + File.separator + "history-snapshot"));
 	}
 
-	public OWLOntology loadSnapShot(OWLOntologyManager manIn, ServerDocument sdoc) throws ClientRequestException {
+	private static Optional<String> getSnapshotChecksum(@Nonnull ProjectId projectId) {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
+		Path path = Paths.get(getSnapShotFile(projectId).get().getAbsolutePath() + SNAPSHOT_CHECKSUM);
+		try {
+			return Optional.of(new String(Files.readAllBytes(path), Charset.defaultCharset()));
+		} catch (IOException e) {
+			return Optional.empty();
+		}
+	}
+
+	public OWLOntology loadSnapShot(OWLOntologyManager manIn, @Nonnull ProjectId pid) throws ClientRequestException {
+		if (pid == null) throw new IllegalArgumentException("projectId is null");
 		try {
 			BinaryOWLOntologyDocumentSerializer serializer = new BinaryOWLOntologyDocumentSerializer();
 			OWLOntology ontIn = manIn.createOntology();
-			BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(getSnapShotFile(sdoc)));
+			BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(getSnapShotFile(pid).get()));
 			serializer.read(inputStream, new BinaryOWLOntologyBuildingHandler(ontIn), manIn.getOWLDataFactory());
 			return ontIn;
 		} catch (IOException | OWLOntologyCreationException e) {
@@ -364,7 +392,8 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private void postProjectSnapShotToServer(Project project, File font) throws LoginTimeoutException,
-			AuthorizationException, ClientRequestException {
+		AuthorizationException, ClientRequestException {
+		Response response = null;
 		try {
 			OWLOntology ont;
 			if (font.getName().endsWith(".zip")) {
@@ -374,18 +403,26 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 				ont = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(font);
 			}
 			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(project.getId(), new SnapShot(ont));
-			post(PROJECT_SNAPSHOT,
-					RequestBody.create(ApplicationContentType, b.toByteArray()),
-					true); // send request to server
-		}
-		catch (IOException | OWLOntologyCreationException e) {
+
+			response = post(PROJECT_SNAPSHOT,
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				true); // send request to server
+
+			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
+			String snapshotChecksum = (String) ois.readObject();
+			writeSnapshotChecksum(project.getId(), snapshotChecksum);
+		} catch (IOException | OWLOntologyCreationException | ClassNotFoundException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
+		} finally {
+			if (response != null) {
+				response.body().close();
+			}
 		}
 	}
 
-	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(ProjectId projectId,
-			SnapShot ontologySnapshot) throws IOException {
+	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(ProjectId projectId, SnapShot ontologySnapshot)
+		throws IOException {
 		ByteArrayOutputStream b = new ByteArrayOutputStream();
 		ObjectOutputStream os = new ObjectOutputStream(b);
 		os.writeObject(projectId);
@@ -393,11 +430,12 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		return b;
 	}
 
-	public void createLocalSnapShot(OWLOntology ont, ServerDocument sdoc) throws ClientRequestException {
+	public void createLocalSnapShot(OWLOntology ont, @Nonnull ProjectId projectId) throws ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
 		BufferedOutputStream outputStream = null;
 		try {
 			BinaryOWLOntologyDocumentSerializer serializer = new BinaryOWLOntologyDocumentSerializer();
-			outputStream = new BufferedOutputStream(new FileOutputStream(getSnapShotFile(sdoc)));
+			outputStream = new BufferedOutputStream(new FileOutputStream(getSnapShotFile(projectId).get()));
 			serializer.write(new OWLOntologyWrapper(ont), new DataOutputStream(outputStream));
 		} catch (IOException e) {
 			logger.error(e.getMessage(), e);
@@ -413,18 +451,21 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		}
 	}
 
-	public SnapShot getSnapShot(ProjectId projectId) throws LoginTimeoutException, AuthorizationException,
-			ClientRequestException {
+	public SnapShot getSnapShot(@Nonnull ProjectId projectId) throws LoginTimeoutException, AuthorizationException,
+		ClientRequestException {
 		String requestUrl = PROJECT_SNAPSHOT + "?projectid=" + projectId.get();
 		Response response = get(requestUrl); // send request to server
-		return retrieveDocumentSnapshotFromServerResponse(response);
+		return retrieveDocumentSnapshotFromServerResponse(response, projectId);
 	}
 
-	private SnapShot retrieveDocumentSnapshotFromServerResponse(Response response)
-			throws ClientRequestException {
+	private SnapShot retrieveDocumentSnapshotFromServerResponse(Response response, @Nonnull ProjectId projectId)
+		throws ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
 		try {
 			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
 			SnapShot snapshot = (SnapShot) ois.readObject();
+			String checksum = (String) ois.readObject();
+			writeSnapshotChecksum(projectId, checksum);
 			return snapshot;
 		} catch (IOException | ClassNotFoundException e) {
 			logger.error(e.getMessage(), e);
@@ -436,48 +477,50 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		}
 	}
 
-	public ChangeHistory getAllChanges(ServerDocument sdoc) throws LoginTimeoutException,
-			AuthorizationException, ClientRequestException {
+	public ChangeHistory getAllChanges(ServerDocument sdoc, @Nonnull ProjectId projectId) throws LoginTimeoutException,
+		AuthorizationException, ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
 		try {
 			HistoryFile historyFile = sdoc.getHistoryFile();
 			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(historyFile);
-			Response response = post(ALL_CHANGES,
-					RequestBody.create(ApplicationContentType, b.toByteArray()),
-					true); // send request to server
+			Response response = postWithProjectId(ALL_CHANGES,
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				projectId,
+				true); // send request to server
 			return retrieveChangeHistoryFromServerResponse(response);
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
 		}
 	}
 
 	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(HistoryFile historyFile)
-			throws IOException {
+		throws IOException {
 		ByteArrayOutputStream b = new ByteArrayOutputStream();
 		ObjectOutputStream os = new ObjectOutputStream(b);
 		os.writeObject(historyFile);
 		return b;
 	}
 
-	public DocumentRevision getRemoteHeadRevision(VersionedOWLOntology vont) throws
-			LoginTimeoutException, AuthorizationException, ClientRequestException {
+	public DocumentRevision getRemoteHeadRevision(VersionedOWLOntology vont, @Nonnull ProjectId projectId) throws
+		AuthorizationException, ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
 		try {
 			HistoryFile historyFile = vont.getServerDocument().getHistoryFile();
 			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(historyFile);
-			Response response = post(HEAD,
-					RequestBody.create(ApplicationContentType, b.toByteArray()),
-					true); // send request to server
+			Response response = postWithProjectId(HEAD,
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				projectId,
+				true); // send request to server
 			return retrieveDocumentRevisionFromServerResponse(response);
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
 		}
 	}
 
 	private DocumentRevision retrieveDocumentRevisionFromServerResponse(Response response)
-			throws ClientRequestException {
+		throws ClientRequestException {
 		try {
 			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
 			DocumentRevision remoteHead = (DocumentRevision) ois.readObject();
@@ -492,30 +535,32 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		}
 	}
 
-	public ChangeHistory getLatestChanges(VersionedOWLOntology vont) throws LoginTimeoutException,
-			AuthorizationException, ClientRequestException {
+	public ChangeHistory getLatestChanges(VersionedOWLOntology vont, @Nonnull ProjectId projectId)
+			throws AuthorizationException, ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
 		DocumentRevision start = vont.getChangeHistory().getHeadRevision();
-		return getLatestChanges(vont.getServerDocument(), start);
+		return getLatestChanges(vont.getServerDocument(), start, projectId);
 	}
 
-	public ChangeHistory getLatestChanges(ServerDocument sdoc, DocumentRevision start)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+	public ChangeHistory getLatestChanges(ServerDocument sdoc, DocumentRevision start, @Nonnull ProjectId projectId)
+		throws AuthorizationException, ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
 		try {
 			HistoryFile historyFile = sdoc.getHistoryFile();
 			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(start, historyFile);
-			Response response = post(LATEST_CHANGES,
-					RequestBody.create(ApplicationContentType, b.toByteArray()),
-					true); // send request to server
+			Response response = postWithProjectId(LATEST_CHANGES,
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				projectId,
+				true); // send request to server
 			return retrieveChangeHistoryFromServerResponse(response);
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
 		}
 	}
 
-	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(DocumentRevision start,
-			HistoryFile historyFile) throws IOException {
+	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(
+			DocumentRevision start, HistoryFile historyFile) throws IOException {
 		ByteArrayOutputStream b = new ByteArrayOutputStream();
 		ObjectOutputStream os = new ObjectOutputStream(b);
 		os.writeObject(historyFile);
@@ -523,13 +568,34 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		return b;
 	}
 
-	
+	public void squashHistory(SnapShot snapshot, @Nonnull ProjectId projectId) throws ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
+		checkSnapshotChecksumPresent(projectId);
+		ByteArrayOutputStream b = new ByteArrayOutputStream();
+		try {
+			ObjectOutputStream oos = new ObjectOutputStream(b);
+			oos.writeObject(snapshot);
+
+			Response response = postWithProjectId(SQUASH,
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				projectId,
+				true);
+
+			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
+			String snapshotChecksum = (String) ois.readObject();
+			writeSnapshotChecksum(projectId, snapshotChecksum);
+
+			createLocalSnapShot(snapshot.getOntology(), projectId);
+		} catch (IOException | AuthorizationException | ClassNotFoundException e) {
+			logger.error(e.getMessage(), e);
+			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
+		}
+	}
 
 	public Role getRole(RoleId id) throws ClientRequestException {
 		return config.getRole(id);
 	}
 
-	
 
 	@Override
 	public UserInfo getUserInfo() {
@@ -542,41 +608,96 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	@Override
-	public List<Role> getActiveRoles() {
+	public List<Role> getActiveRoles(ProjectId projectId) {
 		List<Role> activeRoles = new ArrayList<>();
-		if (getRemoteProject().isPresent()) {
-			activeRoles = config.getRoles(userId, getRemoteProject().get(), GlobalPermissions.INCLUDED);
+		if (projectId != null) {
+			activeRoles = config.getRoles(userId, projectId, GlobalPermissions.INCLUDED);
 		}
 		return activeRoles;
 	}
 
 	@Override
-	public List<Operation> getActiveOperations() {
+	public List<Operation> getActiveOperations(ProjectId projectId) {
 		List<Operation> activeOperations = new ArrayList<>();
-		if (getRemoteProject().isPresent()) {
-			activeOperations = config.getOperations(userId, getRemoteProject().get());
+		if (projectId != null) {
+			activeOperations = config.getOperations(userId, projectId);
 		}
 		return activeOperations;
 	}
 
-	private Response post(String url, RequestBody body, boolean withCredential)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
-		Request request = null;
-		if (withCredential) {
-			request = new Request.Builder()
-					.url(serverAddress + url)
-					.addHeader(authHeader, getAuthHeaderString())
-					.post(body)
-					.build();
+	private Request.Builder postBuilder(String url, RequestBody body, boolean withCredential) {
+		Request.Builder builder = new Request.Builder()
+			.url(serverAddress + url)
+			.post(body);
 
-		} else {
-			request = new Request.Builder()
-					.url(serverAddress + url)
-					.post(body)
-					.build();
+		if (withCredential) {
+			builder = builder.addHeader(authHeader, getAuthHeaderString());
 		}
+		return builder;
+	}
+
+	private Response postWithProjectId(String url, RequestBody body, @Nonnull ProjectId projectId, boolean withCredential)
+			throws AuthorizationException, ClientRequestException {
+		if (projectId == null) {
+			throw new RuntimeException("POST projectId is null: " + url);
+		}
+		Optional<String> snapshotChecksum = getSnapshotChecksum(projectId);
+		if (!snapshotChecksum.isPresent()) {
+			throw new RuntimeException("POST snapshot checksum is missing");
+		}
+
+		Request.Builder builder = postBuilder(url, body, withCredential);
+
+		builder.addHeader(ServerProperties.PROJECTID_HEADER, projectId.get());
+		builder.addHeader(ServerProperties.SNAPSHOT_CHECKSUM_HEADER, snapshotChecksum.get());
+
 		try {
-			Response response = httpClient.newCall(request).execute();
+			Response response = httpClient.newCall(builder.build()).execute();
+
+			if (!response.isSuccessful() && response.code() == ServerProperties.HISTORY_SNAPSHOT_OUT_OF_DATE) {
+				ListeningExecutorService service = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+				ProgressDialog dlg = new ProgressDialog();
+
+				dlg.setMessage("History snapshot out of date. Fetching latest.");
+				final ListenableFuture<?> snapshotTask = service.submit(() -> {
+					try {
+						SnapShot snapshot = getSnapShot(projectId);
+						createLocalSnapShot(snapshot.getOntology(), projectId);
+					} catch (AuthorizationException | ClientRequestException e) {
+						throw new RuntimeException(e);
+					}
+					finally {
+						dlg.setVisible(false);
+					}
+				});
+				dlg.setVisible(true);
+
+				String newChecksum = getSnapshotChecksum(projectId).get();
+
+				builder = postBuilder(url, body, withCredential)
+						.addHeader(ServerProperties.PROJECTID_HEADER, projectId.get())
+						.addHeader(ServerProperties.SNAPSHOT_CHECKSUM_HEADER, newChecksum);
+
+				response = httpClient.newCall(builder.build()).execute();
+			}
+
+			if (!response.isSuccessful()) {
+				throwRequestExceptions(response);
+			}
+			return response;
+		} catch (IOException e) {
+			logger.error(e.getMessage(), e);
+			throw new ClientRequestException("Unable to send request to server (see error log for details)", e);
+		}
+	}
+
+	private Response post(String url, RequestBody body, boolean withCredential)
+		throws AuthorizationException, ClientRequestException {
+		Request.Builder builder = postBuilder(url, body, withCredential);
+
+		try {
+			Response response = httpClient.newCall(builder.build()).execute();
+
 			if (!response.isSuccessful()) {
 				throwRequestExceptions(response);
 			}
@@ -588,19 +709,19 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private Response delete(String url, boolean withCredential) throws LoginTimeoutException,
-			AuthorizationException, ClientRequestException  {
+		AuthorizationException, ClientRequestException {
 		Request request;
 		if (withCredential) {
 			request = new Request.Builder()
-					.url(serverAddress + url)
-					.addHeader(authHeader, getAuthHeaderString())
-					.delete()
-					.build();
+				.url(serverAddress + url)
+				.addHeader(authHeader, getAuthHeaderString())
+				.delete()
+				.build();
 		} else {
 			request = new Request.Builder()
-					.url(serverAddress + url)
-					.delete()
-					.build();
+				.url(serverAddress + url)
+				.delete()
+				.build();
 		}
 		try {
 			Response response = httpClient.newCall(request).execute();
@@ -615,12 +736,12 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private Response get(String url) throws LoginTimeoutException, AuthorizationException,
-			ClientRequestException {
+		ClientRequestException {
 		Request request = new Request.Builder()
-				.url(serverAddress + url)
-				.addHeader(authHeader, getAuthHeaderString())
-				.get()
-				.build();
+			.url(serverAddress + url)
+			.addHeader(authHeader, getAuthHeaderString())
+			.get()
+			.build();
 		try {
 			Response response = httpClient.newCall(request).execute();
 			if (!response.isSuccessful()) {
@@ -639,7 +760,7 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private ServerConfiguration getServerConfig() throws LoginTimeoutException, AuthorizationException,
-			ClientRequestException {
+		ClientRequestException {
 		Response response = get(METAPROJECT);
 		try {
 			return ConfigurationManager.getConfigurationLoader().loadConfiguration(new InputStreamReader(response.body().byteStream()));
@@ -653,27 +774,28 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		}
 	}
 
-	public List<String> getCodes(int no) throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+	public List<String> getCodes(int no, @Nonnull ProjectId projectId) throws
+		LoginTimeoutException, AuthorizationException, ClientRequestException {
 		return retrieveCodesFromServerResponse(get(GEN_CODE + "?count=" + no + "&projectid=" + projectId.get()));
-	}	
- 
-	
+	}
+
+
 	public void saveConfig() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		post(METAPROJECT,
-				RequestBody.create(JsonContentType, serl.write(config.getCurrentConfig(), ServerConfiguration.class)),
-				true); // send request to server
+			RequestBody.create(JsonContentType, serl.write(config.getCurrentConfig(), ServerConfiguration.class)),
+			true); // send request to server
 		sleep(1000); // give the server some time to reboot
 		initConfig();
 	}
-	
+
 	public void pauseServer() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
-		get(SERVER_PAUSE);		
-		
+		get(SERVER_PAUSE);
+
 	}
-	
+
 	public void resumeServer() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
-		get(SERVER_RESUME);		
-		
+		get(SERVER_RESUME);
+
 	}
 
 	private static void sleep(int period) {
@@ -684,34 +806,40 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		}
 	}
 
-	public void putEVSHistory(String code, String name, String operation, String reference)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+	public void putEVSHistory(String code, String name, String operation, String reference, @Nonnull ProjectId projectId)
+		throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		try {
 			History evsHistory = new History(userId.get(), code, name, operation, reference);
 			ByteArrayOutputStream b = writeRequestArgumentsIntoByteStream(evsHistory);
 			post(EVS_REC + "?projectid=" + projectId.get(),
-					RequestBody.create(ApplicationContentType, b.toByteArray()),
-					true); // send request to server
+				RequestBody.create(ApplicationContentType, b.toByteArray()),
+				true); // send request to server
 		} catch (IOException e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Failed to send data (see error log for details)", e);
 		}
 	}
-	
-	public void genConceptHistory()
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+
+	public void genConceptHistory(@Nonnull ProjectId projectId)
+		throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+		if (projectId == null) throw new IllegalArgumentException("projectId cannot be null");
 		try {
-			
 			get(GEN_CON_HIST + "?projectid=" + projectId.get());
-			
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);
 			throw new ClientRequestException("Failed to successfuly generate concept history.", e);
 		}
 	}
 
+	private void writeSnapshotChecksum(@Nonnull ProjectId projectId, String checksum) throws IOException {
+		if (projectId == null) throw new IllegalArgumentException("projectId is null");
+		File snapshotFile = getSnapShotFile(projectId).get();
+		OutputStream checksumStream = new FileOutputStream(snapshotFile.getAbsolutePath() + SNAPSHOT_CHECKSUM);
+		checksumStream.write(checksum.getBytes());
+	}
+
 	private ByteArrayOutputStream writeRequestArgumentsIntoByteStream(History hist)
-			throws IOException {
+		throws IOException {
 		ByteArrayOutputStream b = new ByteArrayOutputStream();
 		ObjectOutputStream os = new ObjectOutputStream(b);
 		os.writeObject(hist);
@@ -719,15 +847,14 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 	}
 
 	private void throwRequestExceptions(Response response)
-			throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+		throws LoginTimeoutException, AuthorizationException, ClientRequestException {
 		String originalMessage = response.header("Error-Message");
 		if (originalMessage == null) {
 			originalMessage = String.format("Unknown server error (code: %d)", response.code());
 		}
 		if (response.code() == StatusCodes.UNAUTHORIZED) {
 			throw new AuthorizationException(originalMessage);
-		}
-		else if (response.code() == StatusCodes.CONFLICT) {
+		} else if (response.code() == StatusCodes.CONFLICT) {
 			throw new SynchronizationException(originalMessage);
 		}
 		/*
@@ -735,71 +862,70 @@ public class LocalHttpClient implements Client, ClientSessionListener {
 		 */
 		else if (response.code() == 440) {
 			throw new LoginTimeoutException(originalMessage);
-		}
-		else if (response.code() == StatusCodes.SERVICE_UNAVAILABLE) {
-			throw new ClientRequestException(originalMessage);
-		}
-		else {
+		} else if (response.code() == StatusCodes.SERVICE_UNAVAILABLE) {
+			throw new ServiceUnavailableException(originalMessage);
+		} else {
 			String msg = String.format("%s (contact server admin for further assistance)", originalMessage);
 			throw new ClientRequestException(msg);
 		}
 	}
 
-
-	
-
-	
-
-	public Optional<ProjectId> getRemoteProject() {
-		return Optional.ofNullable(projectId);
-	}
-	
 	public boolean codeIsLessThan(String lower, String upper) {
-	
-	String p = config.getCurrentConfig().getProperty(CODEGEN_PREFIX);
-	String s = config.getCurrentConfig().getProperty(CODEGEN_SUFFIX);
-	String d = config.getCurrentConfig().getProperty(CODEGEN_DELIMETER);
-	
-	int lowNum = 0;
-	int upNum = 0;
-	
-	if (d != null) {
-		String[] lowSplit = lower.split(d);
-		String[] upSplit = upper.split(d);
-		lowNum = Integer.parseInt(lowSplit[1]);
-		upNum = Integer.parseInt(upSplit[1]);
-		
-	} else {
-		String lowRem = lower.substring(p.length());
-		String upRem = upper.substring(p.length());
-		if (s != null) {
-			lowNum = Integer.parseInt(lowRem.substring(0, lowRem.length() - s.length()));
-			upNum = Integer.parseInt(upRem.substring(0, upRem.length() - s.length()));
+
+		String p = config.getCurrentConfig().getProperty(CODEGEN_PREFIX);
+		String s = config.getCurrentConfig().getProperty(CODEGEN_SUFFIX);
+		String d = config.getCurrentConfig().getProperty(CODEGEN_DELIMETER);
+
+		int lowNum = 0;
+		int upNum = 0;
+
+		if (d != null) {
+			String[] lowSplit = lower.split(d);
+			String[] upSplit = upper.split(d);
+			lowNum = Integer.parseInt(lowSplit[1]);
+			upNum = Integer.parseInt(upSplit[1]);
+
 		} else {
-			lowNum = Integer.parseInt(lowRem);
-			upNum = Integer.parseInt(upRem);
-			
+			String lowRem = lower.substring(p.length());
+			String upRem = upper.substring(p.length());
+			if (s != null) {
+				lowNum = Integer.parseInt(lowRem.substring(0, lowRem.length() - s.length()));
+				upNum = Integer.parseInt(upRem.substring(0, upRem.length() - s.length()));
+			} else {
+				lowNum = Integer.parseInt(lowRem);
+				upNum = Integer.parseInt(upRem);
+
+			}
+		}
+		return lowNum < upNum;
+
+
+	}
+
+	public boolean isWorkFlowManager(ProjectId projectId) {
+		try {
+			Role wfm = getRole(new RoleIdImpl("mp-project-manager"));
+			return getActiveRoles(projectId).contains(wfm);
+		} catch (ClientRequestException e) {
+			e.printStackTrace();
+			return false;
 		}
 	}
-	return lowNum < upNum;
-	
-	
-	}
-	
-	public boolean isWorkFlowManager() { 
-    	
-    		try {
-    			Role wfm = getRole(new RoleIdImpl("mp-project-manager"));
-    			return getActiveRoles().contains(wfm);
-    		} catch (ClientRequestException e) {
-    			e.printStackTrace();
-    			return false;
-    		}
-    	
-    }
 
-	public void setProjectId(ProjectId projectId) {
-		this.projectId = projectId;
+	public ServerStatus getServerStatus() throws ClientRequestException {
+		Response response = null;
+		try {
+			response = get(SERVER_STATUS);
+			ObjectInputStream ois = new ObjectInputStream(response.body().byteStream());
+			ServerStatus serverStatus = (ServerStatus) ois.readObject();
+			return serverStatus;
+		} catch (IOException | ClassNotFoundException | AuthorizationException e) {
+			logger.error(e.getMessage(), e);
+			throw new ClientRequestException("Failed to read data from server (see error log for details)", e);
+		} finally {
+			if (response != null) {
+				response.body().close();
+			}
+		}
 	}
-
 }

--- a/src/main/java/org/protege/editor/owl/client/api/Client.java
+++ b/src/main/java/org/protege/editor/owl/client/api/Client.java
@@ -1,5 +1,6 @@
 package org.protege.editor.owl.client.api;
 
+import edu.stanford.protege.metaproject.api.*;
 import org.protege.editor.owl.client.api.exception.AuthorizationException;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
 import org.protege.editor.owl.client.api.exception.SynchronizationException;
@@ -9,18 +10,6 @@ import org.protege.editor.owl.server.versioning.api.ChangeHistory;
 import org.protege.editor.owl.server.versioning.api.ServerDocument;
 
 import java.util.List;
-import java.util.Optional;
-
-import edu.stanford.protege.metaproject.api.AuthToken;
-import edu.stanford.protege.metaproject.api.Description;
-import edu.stanford.protege.metaproject.api.Name;
-import edu.stanford.protege.metaproject.api.Operation;
-import edu.stanford.protege.metaproject.api.OperationId;
-import edu.stanford.protege.metaproject.api.Project;
-import edu.stanford.protege.metaproject.api.ProjectId;
-import edu.stanford.protege.metaproject.api.ProjectOptions;
-import edu.stanford.protege.metaproject.api.Role;
-import edu.stanford.protege.metaproject.api.UserId;
 
 /**
  * @author Josef Hardi <johardi@stanford.edu> <br>
@@ -84,12 +73,12 @@ public interface Client {
     /**
      * Gets a list of role assigned to the user of this client, considering the current active project
      */
-    List<Role> getActiveRoles() throws ClientRequestException;
+    List<Role> getActiveRoles(ProjectId projectId) throws ClientRequestException;
 
     /**
      * Gets a list of operation assigned to the use of this client, considering the current active project
      */
-    List<Operation> getActiveOperations() throws ClientRequestException;
+    List<Operation> getActiveOperations(ProjectId projectId) throws ClientRequestException;
 
 	
 	

--- a/src/main/java/org/protege/editor/owl/client/api/exception/ServiceUnavailableException.java
+++ b/src/main/java/org/protege/editor/owl/client/api/exception/ServiceUnavailableException.java
@@ -1,0 +1,10 @@
+package org.protege.editor.owl.client.api.exception;
+
+
+public class ServiceUnavailableException extends ClientRequestException {
+	private static final long serialVersionUID = -68690921478820530L;
+
+	public ServiceUnavailableException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/protege/editor/owl/client/ui/ChangeHistoryPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/ui/ChangeHistoryPanel.java
@@ -31,7 +31,9 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
+import edu.stanford.protege.metaproject.api.ProjectId;
 import org.protege.editor.owl.OWLEditorKit;
+import org.protege.editor.owl.client.ClientSession;
 import org.protege.editor.owl.client.LocalHttpClient;
 import org.protege.editor.owl.client.api.exception.AuthorizationException;
 import org.protege.editor.owl.client.api.exception.ClientRequestException;
@@ -111,7 +113,8 @@ public class ChangeHistoryPanel extends JPanel {
     }
 
     private JComponent getHistoryComponent() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
-        ChangeHistory remoteChanges = LocalHttpClient.current_user().getAllChanges(vont.getServerDocument());
+        ProjectId projectId = ClientSession.getInstance(editorKit).getActiveProject();
+        ChangeHistory remoteChanges = LocalHttpClient.current_user().getAllChanges(vont.getServerDocument(), projectId);
         HistoryTableModel model = new HistoryTableModel(remoteChanges);
         final JTable table = new JTable(model);
         table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {


### PR DESCRIPTION
* Use ProjectId instead of project name for identifying snapshots
* Check for out of date history snapshot
* Include history snapshot checksum in POST calls in a custom header(only really
  need it in HTTPChangeService calls).
* Add ProjectId to all HTTPChangeService calls.
* Rewrite POST method to fetch new snapshot and retry on out of date snapshot error code.
* Add progress indicators to squash history and snapshot fetch
* Disable Pause menu on Ontology open if already paused
* remove projectId instance variable from client