### PR TITLE
Remove request retry after re-fetching snapshot

### DIFF
--- a/src/main/java/org/protege/editor/owl/client/ClientSession.java
+++ b/src/main/java/org/protege/editor/owl/client/ClientSession.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import javax.annotation.Nullable;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
@@ -154,6 +155,7 @@ public class ClientSession extends OWLEditorKitHook {
         return projectMap.get(ontologyId);
     }
 
+    @Nullable
     public VersionedOWLOntology getActiveVersionOntology() {
         OWLOntologyID ontologyId = getEditorKit().getOWLModelManager().getActiveOntology().getOntologyID();
         return ontologyMap.get(ontologyId);

--- a/src/main/java/org/protege/editor/owl/client/action/CommitAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/CommitAction.java
@@ -44,8 +44,6 @@ public class CommitAction extends AbstractClientAction implements ClientSessionL
 
     private static final long serialVersionUID = 4601012273632698091L;
 
-    private Optional<VersionedOWLOntology> activeVersionOntology = Optional.empty();
-
     private List<OWLOntologyChange> localChanges = new ArrayList<>();
 
     private SessionRecorder sessionRecorder;
@@ -54,8 +52,9 @@ public class CommitAction extends AbstractClientAction implements ClientSessionL
         @Override
         public void stateChanged(HistoryManager source) {
             OWLOntology activeOntology = getOWLEditorKit().getOWLModelManager().getActiveOntology();
-            if (activeVersionOntology.isPresent()) {
-                ChangeHistory baseline = activeVersionOntology.get().getChangeHistory();
+            VersionedOWLOntology versionedOWLOntology = getClientSession().getActiveVersionOntology();
+            if (null != versionedOWLOntology) {
+                ChangeHistory baseline = versionedOWLOntology.getChangeHistory();
                 localChanges = ClientUtils.getUncommittedChanges(source, activeOntology, baseline);
                 setEnabled(!localChanges.isEmpty());
             }
@@ -84,8 +83,7 @@ public class CommitAction extends AbstractClientAction implements ClientSessionL
              * This method does not handle if version ontology is present because the menu item will
              * only be enabled if checkUncommittedChanges(...) listener senses changes in the ontology.
              */
-            activeVersionOntology = Optional.ofNullable(event.getSource().getActiveVersionOntology());
-            if (!activeVersionOntology.isPresent()) {
+            if (null != event.getSource().getActiveVersionOntology()) {
                 setEnabled(false);
             }
         }
@@ -98,7 +96,7 @@ public class CommitAction extends AbstractClientAction implements ClientSessionL
         if (option == JOptionPane.OK_OPTION) {
             String comment = commitPanel.getTextArea().getText().trim();
             if (!comment.isEmpty()) {
-                performCommit(activeVersionOntology.get(), comment);
+                performCommit(getClientSession().getActiveVersionOntology(), comment);
             }
         }
     }
@@ -149,7 +147,7 @@ public class CommitAction extends AbstractClientAction implements ClientSessionL
     }
 
     private void recommit(String comment) {
-        performCommit(activeVersionOntology.get(), comment);
+        performCommit(getClientSession().getActiveVersionOntology(), comment);
     }
 
     private class DoCommit implements Callable<ChangeHistory> {

--- a/src/main/java/org/protege/editor/owl/client/action/ShowHistoryAction.java
+++ b/src/main/java/org/protege/editor/owl/client/action/ShowHistoryAction.java
@@ -34,8 +34,6 @@ public class ShowHistoryAction extends AbstractClientAction implements ClientSes
 
     private static final long serialVersionUID = -7628375950917155764L;
 
-    private Optional<VersionedOWLOntology> activeVersionOntology = Optional.empty();
-
     @Override
     public void initialise() throws Exception {
         super.initialise();
@@ -51,8 +49,7 @@ public class ShowHistoryAction extends AbstractClientAction implements ClientSes
     @Override
     public void handleChange(ClientSessionChangeEvent event) {
         if (event.hasCategory(EventCategory.SWITCH_ONTOLOGY)) {
-            activeVersionOntology = Optional.ofNullable(event.getSource().getActiveVersionOntology());
-            setEnabled(activeVersionOntology.isPresent());
+            setEnabled(null != event.getSource().getActiveVersionOntology());
         }
     }
 
@@ -84,9 +81,9 @@ public class ShowHistoryAction extends AbstractClientAction implements ClientSes
         openShowHistoryDialog();
     }
 
-    private JDialog createDialog() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
+    private JDialog createDialog() throws AuthorizationException, ClientRequestException {
         final JDialog dialog = new JDialog(null, "Browse Change History", Dialog.ModalityType.MODELESS);
-        ChangeHistoryPanel changeHistoryPanel = new ChangeHistoryPanel(activeVersionOntology.get(), getOWLEditorKit());
+        ChangeHistoryPanel changeHistoryPanel = new ChangeHistoryPanel(getOWLEditorKit());
         changeHistoryPanel.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "CLOSE_DIALOG");
         changeHistoryPanel.getActionMap().put("CLOSE_DIALOG", new AbstractAction()
         {

--- a/src/main/java/org/protege/editor/owl/client/ui/ChangeHistoryPanel.java
+++ b/src/main/java/org/protege/editor/owl/client/ui/ChangeHistoryPanel.java
@@ -58,25 +58,21 @@ public class ChangeHistoryPanel extends JPanel {
     private static final long serialVersionUID = -372532962143290188L;
 
     private OWLEditorKit editorKit;
-    private OWLOntology ontology;
-    private VersionedOWLOntology vont;
 
     private JTable changeListTable;
     private ChangeListTableModel changeListTableModel;
 
-    public ChangeHistoryPanel(VersionedOWLOntology vont, OWLEditorKit editorKit)
+    public ChangeHistoryPanel(OWLEditorKit editorKit)
             throws LoginTimeoutException, AuthorizationException, ClientRequestException {
-        this.vont = vont;
         this.editorKit = editorKit;
-        this.ontology = editorKit.getOWLModelManager().getActiveOntology();
         initUI();
     }
 
     private void initUI() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
         String shortOntologyName = "";
-        OWLOntologyID ontologyId = ontology.getOntologyID();
+        OWLOntologyID ontologyId = editorKit.getOWLModelManager().getActiveOntology().getOntologyID();
         if (!ontologyId.isAnonymous()) {
-            shortOntologyName = ontology.getOntologyID().getOntologyIRI().get().getRemainder().get();
+            shortOntologyName = ontologyId.getOntologyIRI().get().getRemainder().get();
         }
         if (shortOntologyName.isEmpty()) {
             shortOntologyName = ontologyId.toString();
@@ -114,12 +110,14 @@ public class ChangeHistoryPanel extends JPanel {
 
     private JComponent getHistoryComponent() throws LoginTimeoutException, AuthorizationException, ClientRequestException {
         ProjectId projectId = ClientSession.getInstance(editorKit).getActiveProject();
+        VersionedOWLOntology vont = ClientSession.getInstance(editorKit).getActiveVersionOntology();
         ChangeHistory remoteChanges = LocalHttpClient.current_user().getAllChanges(vont.getServerDocument(), projectId);
         HistoryTableModel model = new HistoryTableModel(remoteChanges);
         final JTable table = new JTable(model);
         table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent listSelectionEvent) {
+                OWLOntology ontology = editorKit.getModelManager().getActiveOntology();
                 List<OWLOntologyChange> changesToDisplay = new ArrayList<OWLOntologyChange>();
                 DocumentRevision baseRevision = remoteChanges.getBaseRevision();
                 for (int row : table.getSelectedRows()) {


### PR DESCRIPTION
because the request may now contain stale data.
The request that triggers the snapshot re-fetch will now fail.
Remove unnecessary caching of ontologies.